### PR TITLE
Improve /cs info "contacts" output

### DIFF
--- a/projectns/hooks.c
+++ b/projectns/hooks.c
@@ -152,7 +152,7 @@ static void chaninfo_hook(hook_channel_req_t *hdata)
 
 			if (strlen(buf) > 80)
 			{
-				command_success_nodata(hdata->si, _("Public contacts: %s"), buf);
+				command_success_nodata(hdata->si, _("Group contacts (public): %s"), buf);
 				buf[0] = '\0';
 			}
 			if (buf[0])
@@ -164,7 +164,7 @@ static void chaninfo_hook(hook_channel_req_t *hdata)
 		}
 
 		if (buf[0])
-			command_success_nodata(hdata->si, _("Public contacts: %s"), buf);
+			command_success_nodata(hdata->si, _("Group contacts (public): %s"), buf);
 
 		if (priv)
 		{
@@ -177,7 +177,7 @@ static void chaninfo_hook(hook_channel_req_t *hdata)
 
 				if (strlen(buf) > 80)
 				{
-					command_success_nodata(hdata->si, _("Unlisted contacts: %s"), buf);
+					command_success_nodata(hdata->si, _("Group contacts (private): %s"), buf);
 					buf[0] = '\0';
 				}
 				if (buf[0])
@@ -189,7 +189,7 @@ static void chaninfo_hook(hook_channel_req_t *hdata)
 			}
 
 			if (buf[0])
-				command_success_nodata(hdata->si, _("Unlisted contacts: %s"), buf);
+				command_success_nodata(hdata->si, _("Group contacts (private): %s"), buf);
 		}
 	}
 


### PR DESCRIPTION
For the 'Contacts' line items in /cs info output:

 * Use "Group contacts" terminology as common used throughout
and historically in the project in /cs info output, retaining the
public / private listing type.

 * Improve consistency, using "public" and "private" terms, over
the current "public" and "unlisted" terms in the output.

This change is consistent with public/private term use 
elsewhere, such as /msg projectserv info output.

Discussed with: jess