### PR TITLE
Set last modified date+user on CS CLAIM

### DIFF
--- a/projectns/cs_claim.c
+++ b/projectns/cs_claim.c
@@ -131,7 +131,7 @@ static void cmd_claim(sourceinfo_t *si, int parc, char *parv[])
 		req.ca = ca;
 		req.oldlevel = ca->level;
 
-		ca->level |= founder_flags;
+		chanacs_modify_simple(ca, founder_flags, 0, si->smu);
 
 		req.newlevel = ca->level;
 


### PR DESCRIPTION
Currently CS CLAIM doesn't update the last modified by date and user when a CS CLAIM is done if an ACL entry for the user already exists. This change makes sure that those fields are overwritten where needed.

Resolves: #11