### PR TITLE
Group contact self-service features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,9 @@ SRCS = \
 	projectns/set.c \
 	projectns/manage.c \
 	projectns/audit.c \
-	projectns/cs_claim.c
+	projectns/cs_claim.c \
+	projectns/cs_listgroupchans.c \
+	projectns/ns_listgroupcloaks.c
 
 # To compile your own modules, add them to SRCS or make blegh.so
 

--- a/help/freenode/cs_listgroupchans
+++ b/help/freenode/cs_listgroupchans
@@ -1,0 +1,12 @@
+Help for LISTGROUPCHANS:
+
+The LISTGROUPCHANS command shows registered channels which belong
+to a namespace that you are a group contact for. If a filter is given,
+only shows the channels which match the filter. Otherwise, all channels
+in your namespaces are reported.
+
+Syntax: LISTGROUPCHANS [filter]
+
+Examples:
+    /msg &nick& LISTGROUPCHANS
+    /msg &nick& LISTGROUPCHANS #coolproject-*

--- a/help/freenode/ns_listgroupcloaks
+++ b/help/freenode/ns_listgroupcloaks
@@ -1,0 +1,12 @@
+Help for LISTGROUPCLOAKS:
+
+The LISTGROUPCLOAKS command shows accounts who are assigned a cloak belonging
+to one of the cloak namespaces you are a group contact for.
+If a filter is given, only shows accounts which match the filter.
+Otherwise, all accounts with cloaks in your namespaces are reported.
+
+Syntax: LISTGROUPCLOAKS [filter]
+
+Examples:
+    /msg &nick& LISTGROUPCLOAKS
+    /msg &nick& LISTGROUPCLOAKS coolproject/*

--- a/projectns/cs_listgroupchans.c
+++ b/projectns/cs_listgroupchans.c
@@ -20,12 +20,8 @@ static void cmd_listgroupchans(sourceinfo_t *si, int parc, char *parv[])
 
 	mowgli_node_t *n;
 	mowgli_list_t *plist = projectsvs->myuser_get_projects(si->smu);
-	unsigned int num_projects = 0;
 
-	MOWGLI_ITER_FOREACH(n, plist->head)
-		num_projects++;
-
-	if (!num_projects)
+	if (!MOWGLI_LIST_LENGTH(plist))
 	{
 		command_fail(si, fault_noprivs, _("You are not an authorized group contact for any project."));
 		return;
@@ -67,10 +63,10 @@ static void cmd_listgroupchans(sourceinfo_t *si, int parc, char *parv[])
 	else
 	{
 		if (filter)
-			command_success_nodata(si, ngettext(N_("\2%d\2 match for pattern \2%s\2"), N_("\2%d\2 matches for pattern \2%s\2"), matches),
+			command_success_nodata(si, ngettext(N_("\2%u\2 match for pattern \2%s\2"), N_("\2%u\2 matches for pattern \2%s\2"), matches),
 			                       matches, filter);
 		else
-			command_success_nodata(si, ngettext(N_("\2%d\2 match"), N_("\2%d\2 matches"), matches), matches);
+			command_success_nodata(si, ngettext(N_("\2%u\2 match"), N_("\2%u\2 matches"), matches), matches);
 	}
 
 	if (filter)
@@ -95,5 +91,5 @@ static void mod_deinit(const module_unload_intent_t unused)
 DECLARE_MODULE_V1
 (
 		"freenode/projectns/cs_listgroupchans", MODULE_UNLOAD_CAPABILITY_OK, mod_init, mod_deinit,
-		"", "freenode <http://www.freenode.net>"
+		"", "Libera Chat <https://libera.chat>"
 );

--- a/projectns/cs_listgroupchans.c
+++ b/projectns/cs_listgroupchans.c
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2023 Ryan Schmidt
+ * Rights to this code are as documented in doc/LICENSE.
+ *
+ * Services awareness of group registrations
+ * ChanServ command for contacts to list channels within their namespaces
+ */
+
+#include "fn-compat.h"
+#include "atheme.h"
+#include "projectns.h"
+
+static void cmd_listgroupchans(sourceinfo_t *si, int parc, char *parv[]);
+
+command_t cs_listgroupchans = { "LISTGROUPCHANS", N_("List channels belonging to your projects."), AC_AUTHENTICATED, 2, cmd_listgroupchans, { .path = "freenode/cs_listgroupchans" } };
+
+static void cmd_listgroupchans(sourceinfo_t *si, int parc, char *parv[])
+{
+	char *filter = parv[0];
+
+	mowgli_node_t *n;
+	mowgli_list_t *plist = projectsvs->myuser_get_projects(si->smu);
+	unsigned int num_projects = 0;
+
+	MOWGLI_ITER_FOREACH(n, plist->head)
+		num_projects++;
+
+	if (!num_projects)
+	{
+		command_fail(si, fault_noprivs, _("You are not an authorized group contact for any project."));
+		return;
+	}
+
+	if (filter)
+		command_success_nodata(si, _("Channels in your projects matching \2%s\2:"), filter);
+	else
+		command_success_nodata(si, _("Channels in your projects:"));
+
+	unsigned int matches = 0;
+	struct mychan *mc;
+	mowgli_patricia_iteration_state_t state;
+
+	MOWGLI_PATRICIA_FOREACH(mc, &state, mclist)
+	{
+		if (filter != NULL && match(filter, mc->name))
+			continue;
+
+		struct projectns *project = projectsvs->channame_get_project(mc->name, NULL);
+		MOWGLI_ITER_FOREACH(n, plist->head)
+		{
+			struct project_contact *contact = n->data;
+			if (project == contact->project)
+			{
+				command_success_nodata(si, "- %s (%s) [%s]", mc->name, mychan_founder_names(mc), project->name);
+				matches++;
+			}
+		}
+	}
+
+	if (matches == 0)
+	{
+		if (filter)
+			command_success_nodata(si, _("No channels matched pattern \2%s\2"), filter);
+		else
+			command_success_nodata(si, _("There are no registered channels in your projects."));
+	}
+	else
+	{
+		if (filter)
+			command_success_nodata(si, ngettext(N_("\2%d\2 match for pattern \2%s\2"), N_("\2%d\2 matches for pattern \2%s\2"), matches),
+			                       matches, filter);
+		else
+			command_success_nodata(si, ngettext(N_("\2%d\2 match"), N_("\2%d\2 matches"), matches), matches);
+	}
+
+	if (filter)
+		logcommand(si, CMDLOG_GET, "LISTGROUPCHANS: \2%s\2", filter);
+	else
+		logcommand(si, CMDLOG_GET, "LISTGROUPCHANS");
+}
+
+static void mod_init(module_t *const restrict m)
+{
+	MODULE_TRY_REQUEST_DEPENDENCY(m, "chanserv/main");
+	if (!use_projectns_main_symbols(m))
+		return;
+	service_named_bind_command("chanserv", &cs_listgroupchans);
+}
+
+static void mod_deinit(const module_unload_intent_t unused)
+{
+	service_named_unbind_command("chanserv", &cs_listgroupchans);
+}
+
+DECLARE_MODULE_V1
+(
+		"freenode/projectns/cs_listgroupchans", MODULE_UNLOAD_CAPABILITY_OK, mod_init, mod_deinit,
+		"", "freenode <http://www.freenode.net>"
+);

--- a/projectns/ns_listgroupcloaks.c
+++ b/projectns/ns_listgroupcloaks.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023 Ryan Schmidt
+ * Rights to this code are as documented in doc/LICENSE.
+ *
+ * Services awareness of group registrations
+ * NickServ command for contacts to list cloaks within their namespaces
+ */
+
+#include "fn-compat.h"
+#include "atheme.h"
+#include "projectns.h"
+
+static void cmd_listgroupcloaks(sourceinfo_t *si, int parc, char *parv[]);
+
+command_t ns_listgroupcloaks = { "LISTGROUPCLOAKS", N_("List accounts with cloaks belonging to your projects."), AC_AUTHENTICATED, 2, cmd_listgroupcloaks, { .path = "freenode/ns_listgroupcloaks" } };
+
+struct cloak_ns {
+	struct projectns *project;
+	char pattern[BUFSIZE];
+};
+
+static void cmd_listgroupcloaks(sourceinfo_t *si, int parc, char *parv[])
+{
+	char *filter = parv[0];
+
+	mowgli_node_t *n, *tn;
+	mowgli_list_t *plist = projectsvs->myuser_get_projects(si->smu);
+	unsigned int num_projects = 0;
+	mowgli_list_t cloak_ns_list = { NULL, NULL, 0 };
+
+	MOWGLI_ITER_FOREACH(n, plist->head)
+	{
+		struct project_contact *contact = n->data;
+		mowgli_node_t *n2;
+
+		MOWGLI_ITER_FOREACH(n2, contact->project->cloak_ns.head)
+		{
+			struct cloak_ns *cns = smalloc(sizeof *cns);
+			cns->project = contact->project;
+			mowgli_strlcpy(cns->pattern, (const char *)n2->data, sizeof cns->pattern);
+			mowgli_strlcat(cns->pattern, "/*", sizeof cns->pattern);
+			mowgli_node_add(cns, mowgli_node_create(), &cloak_ns_list);
+		}
+
+		num_projects++;
+	}
+
+	if (!num_projects)
+	{
+		command_fail(si, fault_noprivs, _("You are not an authorized group contact for any project."));
+		return;
+	}
+
+	if (filter)
+		command_success_nodata(si, _("Assigned cloaks in your projects matching \2%s\2:"), filter);
+	else
+		command_success_nodata(si, _("Assigned cloaks in your projects:"));
+
+	unsigned int matches = 0;
+	struct myentity *mt;
+	struct myuser *mu;
+	struct metadata *md;
+	struct myentity_iteration_state state;
+
+	MYENTITY_FOREACH_T(mt, &state, ENT_USER)
+	{
+		mu = user(mt);
+		md = metadata_find(mu, "private:usercloak");
+		if (md == NULL)
+			continue;
+
+		if (filter != NULL && match(filter, md->value))
+			continue;
+
+		MOWGLI_ITER_FOREACH(n, cloak_ns_list.head)
+		{
+			struct cloak_ns *cns = (struct cloak_ns*)n->data;
+			if (!match(cns->pattern, md->value))
+			{
+				command_success_nodata(si, "- %s (%s) [%s]", md->value, mt->name, cns->project->name);
+				matches++;
+				break;
+			}
+		}
+	}
+
+	if (matches == 0)
+	{
+		if (filter)
+			command_success_nodata(si, _("No assigned cloaks matched pattern \2%s\2"), filter);
+		else
+			command_success_nodata(si, _("There are no assigned cloaks in your projects."));
+	}
+	else
+	{
+		if (filter)
+			command_success_nodata(si,
+				ngettext(N_("\2%d\2 match for pattern \2%s\2"), N_("\2%d\2 matches for pattern \2%s\2"), matches),
+				matches, filter);
+		else
+			command_success_nodata(si, ngettext(N_("\2%d\2 match"), N_("\2%d\2 matches"), matches), matches);
+	}
+
+	if (filter)
+		logcommand(si, CMDLOG_GET, "LISTGROUPCLOAKS: \2%s\2", filter);
+	else
+		logcommand(si, CMDLOG_GET, "LISTGROUPCLOAKS");
+
+	MOWGLI_ITER_FOREACH_SAFE(n, tn, cloak_ns_list.head)
+	{
+		mowgli_node_delete(n, &cloak_ns_list);
+		sfree(n->data);
+		mowgli_node_free(n);
+	}
+}
+
+static void mod_init(module_t *const restrict m)
+{
+	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/main");
+	if (!use_projectns_main_symbols(m))
+		return;
+	service_named_bind_command("nickserv", &ns_listgroupcloaks);
+}
+
+static void mod_deinit(const module_unload_intent_t unused)
+{
+	service_named_unbind_command("nickserv", &ns_listgroupcloaks);
+}
+
+DECLARE_MODULE_V1
+(
+		"freenode/projectns/ns_listgroupcloaks", MODULE_UNLOAD_CAPABILITY_OK, mod_init, mod_deinit,
+		"", "freenode <http://www.freenode.net>"
+);

--- a/projectns/ns_listgroupcloaks.c
+++ b/projectns/ns_listgroupcloaks.c
@@ -95,10 +95,10 @@ static void cmd_listgroupcloaks(sourceinfo_t *si, int parc, char *parv[])
 	{
 		if (filter)
 			command_success_nodata(si,
-				ngettext(N_("\2%d\2 match for pattern \2%s\2"), N_("\2%d\2 matches for pattern \2%s\2"), matches),
+				ngettext(N_("\2%u\2 match for pattern \2%s\2"), N_("\2%u\2 matches for pattern \2%s\2"), matches),
 				matches, filter);
 		else
-			command_success_nodata(si, ngettext(N_("\2%d\2 match"), N_("\2%d\2 matches"), matches), matches);
+			command_success_nodata(si, ngettext(N_("\2%u\2 match"), N_("\2%u\2 matches"), matches), matches);
 	}
 
 	if (filter)
@@ -108,7 +108,6 @@ static void cmd_listgroupcloaks(sourceinfo_t *si, int parc, char *parv[])
 
 	MOWGLI_ITER_FOREACH_SAFE(n, tn, cloak_ns_list.head)
 	{
-		mowgli_node_delete(n, &cloak_ns_list);
 		sfree(n->data);
 		mowgli_node_free(n);
 	}
@@ -130,5 +129,5 @@ static void mod_deinit(const module_unload_intent_t unused)
 DECLARE_MODULE_V1
 (
 		"freenode/projectns/ns_listgroupcloaks", MODULE_UNLOAD_CAPABILITY_OK, mod_init, mod_deinit,
-		"", "freenode <http://www.freenode.net>"
+		"", "Libera Chat <https://libera.chat>"
 );


### PR DESCRIPTION
- GCs will now be shown all group contacts, both public and unlisted, for their own projects in ChanServ INFO output.
- Online GCs will be notified by ProjectServ whenever a channel is registered inside of their namespace.
- A new command ChanServ LISTGROUPCHANS for GCs to list all channels (optionally filtered by a pattern) for their projects.
- A new command NickServ LISTGROUPCLOAKS for GCs to list all cloaks (optionally filtered by a pattern) for their projects.