### PR TITLE
Support listing dual cloaks with LISTGROUPCLOAK

### DIFF
--- a/projectns/ns_listgroupcloaks.c
+++ b/projectns/ns_listgroupcloaks.c
@@ -16,6 +16,8 @@ command_t ns_listgroupcloaks = { "LISTGROUPCLOAKS", N_("List accounts with cloak
 
 struct cloak_ns {
 	struct projectns *project;
+	size_t main_len;
+	size_t dual_len;
 	char main_pattern[HOSTLEN + 1];
 	char dual_pattern[HOSTLEN + 1];
 };
@@ -40,10 +42,12 @@ static void cmd_listgroupcloaks(sourceinfo_t *si, int parc, char *parv[])
 			cns->project = contact->project;
 			// main pattern matches project/* for regular cloaks
 			mowgli_strlcpy(cns->main_pattern, (const char *)n2->data, sizeof cns->main_pattern);
-			mowgli_strlcat(cns->main_pattern, "/*", sizeof cns->main_pattern);
+			mowgli_strlcat(cns->main_pattern, "/", sizeof cns->main_pattern);
 			// dual pattern matches project.* after the rightmost / for dual cloaks (project1/project2.foo)
 			mowgli_strlcpy(cns->dual_pattern, (const char *)n2->data, sizeof cns->dual_pattern);
-			mowgli_strlcat(cns->dual_pattern, ".*", sizeof cns->dual_pattern);
+			mowgli_strlcat(cns->dual_pattern, ".", sizeof cns->dual_pattern);
+			cns->main_len = strlen(cns->main_pattern);
+			cns->dual_len = strlen(cns->dual_pattern);
 			mowgli_node_add(cns, mowgli_node_create(), &cloak_ns_list);
 		}
 
@@ -85,7 +89,7 @@ static void cmd_listgroupcloaks(sourceinfo_t *si, int parc, char *parv[])
 		MOWGLI_ITER_FOREACH(n, cloak_ns_list.head)
 		{
 			struct cloak_ns *cns = (struct cloak_ns*)n->data;
-			if (!match(cns->main_pattern, md->value) || !match(cns->dual_pattern, slash + 1))
+			if (!strncmp(cns->main_pattern, md->value, cns->main_len) || !strncmp(cns->dual_pattern, slash + 1, cns->dual_len))
 			{
 				command_success_nodata(si, "- %s (%s) [%s]", md->value, mt->name, cns->project->name);
 				matches++;


### PR DESCRIPTION
Dual cloaks take the form `project1/project2.foo` or `project1/role1/project2.role2.foo` so we would like GCs of project2 to be able to see which people have dual cloaks for their projects. We accomplish this by finding the rightmost `/` in the cloak and then checking for the prefix `project2.` after that point.

This also reduces the buffers needed to store these two prefixes, as we know the maximum length a cloak can be, and it is a lot less than BUFSIZE, so despite now storing two prefixes per cloak namespace we overall allocate less memory than the previous implementation.