### PR TITLE
Add module to reject spurious certificate fingerprints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SRCS = \
 	regnotice.c \
 	noemailnotice.c \
 	ns_defaultcloak.c \
+	ns_rejectcertfp.c \
 	os_regts.c \
 	os_klinechan.c \
 	projectns/help.c \

--- a/ns_rejectcertfp.c
+++ b/ns_rejectcertfp.c
@@ -1,0 +1,54 @@
+/*
+ * Rejects certificate fingerprint additions unless they appear
+ * to be hexadecimal SHA2-512 hashes.
+ */
+
+#include "atheme.h"
+
+#define NETCERTFPLEN 128U
+
+static void
+rejectcertfp_user_certfp_add(struct hook_user_certfp *const restrict req)
+{
+	return_if_fail(req != NULL);
+	return_if_fail(req->si != NULL);
+
+	if (! req->certfp[0])
+		// Another hook already rejected the fingerprint
+		return;
+
+	/* Strip colons as colon-separated hexadecimal bytes (2 characters)
+	 * is the default output format of some tools like openssl-x509(1)
+	 */
+	(void) replace(req->certfp, sizeof req->certfp, ":", "");
+
+	if (strlen(req->certfp) != NETCERTFPLEN)
+		goto invalid;
+
+	for (size_t i = 0; i < NETCERTFPLEN; i++)
+		if (! isxdigit((unsigned char) req->certfp[i]))
+			goto invalid;
+
+	return;
+
+invalid:
+	(void) memset(req->certfp, 0x00, sizeof req->certfp);
+	(void) command_fail(req->si, fault_badparams, _("Fingerprints on this network must be SHA2-512 digests "
+	                                                "consisting of %u hexadecimal characters"), NETCERTFPLEN);
+}
+
+static void
+mod_init(struct module *const restrict m)
+{
+	MODULE_TRY_REQUEST_DEPENDENCY(m, "nickserv/cert");
+
+	(void) hook_add_user_certfp_add(&rejectcertfp_user_certfp_add);
+}
+
+static void
+mod_deinit(const enum module_unload_intent ATHEME_VATTR_UNUSED intent)
+{
+	(void) hook_del_user_certfp_add(&rejectcertfp_user_certfp_add);
+}
+
+SIMPLE_DECLARE_MODULE_V1("freenode/ns_rejectcertfp", MODULE_UNLOAD_CAPABILITY_OK)


### PR DESCRIPTION
It's quite common that people add fingerprints with the wrong digest algorithm, and rarer but not unheard of for people to add complete garbage (services doesn't care about the format).

This module checks for 128 hexadecimal characters; rejecting everything else with an explanatory error message to that effect.